### PR TITLE
shortened the output for "rake config"

### DIFF
--- a/lib/motion/project/cocoapods.rb
+++ b/lib/motion/project/cocoapods.rb
@@ -126,7 +126,7 @@ module Motion::Project
     end
 
     def inspect
-      @podfile.dependencies.inspect
+      ''
     end
   end
 end

--- a/spec/cocoapods_spec.rb
+++ b/spec/cocoapods_spec.rb
@@ -92,7 +92,7 @@ describe "CocoaPodsConfig" do
   end
 
   it 'should produce reasonably short config output' do
-    @config.pods.inspect.should == '[<Pod::Dependency type=:runtime name="Reachability" requirements="= 2.0.5">, <Pod::Dependency type=:runtime name="ASIHTTPRequest/ASIWebPageRequest" requirements="= 1.8.1">]'
+    @config.pods.inspect.should == ''
   end
 
 end


### PR DESCRIPTION
Abreviates the output from motion-cocoapods when typing "rake config" as it was so long I had trouble reading anything else
