### PR TITLE
Update cocoapods.rb

### DIFF
--- a/lib/motion/project/cocoapods.rb
+++ b/lib/motion/project/cocoapods.rb
@@ -63,7 +63,7 @@ module Motion::Project
       @config = config
 
       @podfile = Pod::Podfile.new {}
-      @podfile.platform (App.respond_to?(:template) ? App.template : :ios), config.deployment_target
+      @podfile.platform((App.respond_to?(:template) ? App.template : :ios), config.deployment_target)
       cp_config.podfile = @podfile
 
       cp_config.skip_repo_update = ENV['COCOAPODS_NO_UPDATE']


### PR DESCRIPTION
fixes Syntax error using ruby-1.9.3-p327
