### PR TITLE
added COCOAPODS_NO_UPDATE check to lib/motion/project/cocoapods.rb on line 53

### DIFF
--- a/lib/motion/project/cocoapods.rb
+++ b/lib/motion/project/cocoapods.rb
@@ -50,7 +50,7 @@ module Motion::Project
         if ENV['COCOCAPODS_UPDATE']
           @pods.install!(true)
         else
-          @pods.install! if need_install
+          @pods.install! if need_install && !ENV['COCOAPODS_NO_UPDATE']
         end
         @pods.link_project
       end


### PR DESCRIPTION
I would really like to be able to NOT update my cocoapods each time I compile my app and this seems to do the trick.

Not sure if it's a long time fix, but for now it should work.
