### PR TITLE
Changing all_load to ObjC to fix linking error

### DIFF
--- a/lib/motion/project/cocoapods.rb
+++ b/lib/motion/project/cocoapods.rb
@@ -152,7 +152,7 @@ module Motion::Project
           if lib_search_paths.length == 0 || File.exist?("/usr/lib/lib#{m[0]}.dylib")
             "/usr/lib/lib#{m[0]}.dylib"
           else
-            "#{lib_search_paths} -all_load -l#{m[0]}"
+            "#{lib_search_paths} -ObjC -l#{m[0]}"
           end
         })
         @config.weak_frameworks.concat(ldflags.scan(/-weak_framework\s+([^\s]+)/).map { |m| m[0] })


### PR DESCRIPTION
Hi,

I was trying to use the pjsip cocoapod, which is a wrapper around a SIP library for iOS. It would crash out at linker time, because files were being linked that both have the same symbols. I discovered this would be resolved by using the `-ObjC` linker flag rather than the `-all_load` one, after [stumbling on another user](http://support.frozenmountain.com/entries/24154673-Is-there-an-alternative-for-the-all-load-in-other-linker-flags-in-Xcode-settings) with the same issue.

After looking at the docs for these flags, I think the `-ObjC` one is right. `-all_load` is a largely undocumented flag that seems to force every file, regardless if it has Objective C object code in it, to be linked in. This is only useful in the rare instance that you need to link in a categories file without any classes in it.

I think for motion-cocoapods to take the default behavior to use `-all_load` is a bad idea and this should be changed. Thought I'm open to another solution if you have a suggestion?

Thanks!
