### PR TITLE
Add `pod setup` step to readme.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -34,6 +34,8 @@ dependency manager.
        end
      end
 
+3. If this is the first time using CocoaPods on your machine, you'll need to run <tt>pod setup</tt>.
+
 That's all. The build system will properly download the given pods and their
 dependencies, build them and link them to your application executable.
 


### PR DESCRIPTION
Simple addition, I know. This step is mentioned in the rubymotion site documentation, but not in this readme. I spent longer-then-I'm-proud-of debugging this, and I hope this addition to the readme will help users in the future.
