### PR TITLE
Fix issue where compilation would fail if using only binary pods

### DIFF
--- a/lib/motion/project/cocoapods.rb
+++ b/lib/motion/project/cocoapods.rb
@@ -213,7 +213,8 @@ module Motion::Project
         @config.vendor_project(PODS_ROOT, :xcode, {
           :target => 'Pods',
           :headers_dir => "{#{header_dirs.join(',')}}",
-          :products => pods_libs.map { |lib_name| "lib#{lib_name}.a" }
+          :products => pods_libs.map { |lib_name| "lib#{lib_name}.a" },
+          :allow_empty_products => (pods_libs.empty? ? true : false),
         }.merge(@vendor_options))
       end
     end


### PR DESCRIPTION
Should fix #121

Requires adding support in the RubyMotion toolchain