### PR TITLE
Try to fix wrong resource path

### DIFF
--- a/lib/motion/project/cocoapods.rb
+++ b/lib/motion/project/cocoapods.rb
@@ -503,6 +503,9 @@ module Motion::Project
         f.each_line do |line|
           if matched = line.match(/install_resource\s+(.*)/)
             path = (matched[1].strip)[1..-2]
+            if path.start_with?('${PODS_ROOT}')
+              path = path.sub('${PODS_ROOT}/', '')
+            end
             if path.include?("$PODS_CONFIGURATION_BUILD_DIR")
               path = File.join(".build", File.basename(path))
             end


### PR DESCRIPTION
Because resource path from Pods-resources.sh contains ${PODS_ROOT}, 
the calculated pathname is wrong `vendor/Pods/${PODS_ROOT}/podname/classes/...`, 
which will cause copy resource files to fail.

Ref: https://github.com/amirrajan/rubymotion-applied/issues/47