### PR TITLE
fix #152 by using the newly available public method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'xcodeproj', '~> 1.4'
-gem 'cocoapods', '1.6.2'
+gem 'cocoapods', '1.7.0'
 
 gem 'bacon'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     motion-cocoapods (1.9.2)
-      cocoapods (~> 1.6.0)
+      cocoapods (>= 1.6.0, <= 1.8.0)
 
 GEM
   remote: https://rubygems.org/
@@ -16,11 +16,11 @@ GEM
     atomos (0.1.3)
     bacon (1.2.0)
     claide (1.0.2)
-    cocoapods (1.6.2)
+    cocoapods (1.7.0)
       activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.6.2)
-      cocoapods-deintegrate (>= 1.0.2, < 2.0)
+      cocoapods-core (= 1.7.0)
+      cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 1.2.2, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
@@ -34,8 +34,8 @@ GEM
       molinillo (~> 0.6.6)
       nap (~> 1.0)
       ruby-macho (~> 1.4)
-      xcodeproj (>= 1.8.1, < 2.0)
-    cocoapods-core (1.6.2)
+      xcodeproj (>= 1.8.2, < 2.0)
+    cocoapods-core (1.7.0)
       activesupport (>= 4.0.2, < 6)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
@@ -79,7 +79,7 @@ PLATFORMS
 
 DEPENDENCIES
   bacon
-  cocoapods (= 1.6.2)
+  cocoapods (= 1.7.0)
   motion-cocoapods!
   rake
   xcodeproj (~> 1.4)

--- a/lib/motion/project/cocoapods.rb
+++ b/lib/motion/project/cocoapods.rb
@@ -95,9 +95,11 @@ module Motion::Project
         App.fail "Unknown CocoaPods platform: #{@config.deploy_platform}"
       end
 
-      @podfile = Pod::Podfile.new(Pathname.new(Rake.original_dir) + 'Rakefile') {}
-      @podfile.platform(platform, config.deployment_target)
-      @podfile.target(TARGET_NAME)
+      @podfile = Pod::Podfile.new(Pathname.new(Rake.original_dir) + 'Rakefile') do
+        platform(platform, config.deployment_target)
+        target(TARGET_NAME)
+        install!('cocoapods', :integrate_targets => false)
+      end
       cp_config.podfile = @podfile
       cp_config.installation_root = Pathname.new(File.expand_path(config.project_dir)) + 'vendor'
 
@@ -237,7 +239,6 @@ module Motion::Project
       FileUtils.rm_rf(resources_dir)
 
       pods_installer.update = update
-      pods_installer.installation_options.integrate_targets = false
       pods_installer.install!
       symlink_framework_headers
       install_resources
@@ -317,7 +318,6 @@ module Motion::Project
     end
 
     def analyzer
-      cp_config = Pod::Config.instance
       Pod::Installer::Analyzer.new(cp_config.sandbox, @podfile, cp_config.lockfile)
     end
 

--- a/motion-cocoapods.gemspec
+++ b/motion-cocoapods.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.license     = 'BSD-2-Clause'
   spec.files       = Dir.glob('lib/**/*.rb') << 'README.md' << 'LICENSE'
 
-  spec.add_runtime_dependency 'cocoapods', '~> 1.6.0'
+  spec.add_runtime_dependency 'cocoapods', '>= 1.6.0', '<= 1.8.0'
 end


### PR DESCRIPTION
Fixes #152. When cocoapods 1.7.0 was released a previously public method,
`installation_options` was made private.