### PR TITLE
Bump cocoapods

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     motion-cocoapods (1.10.0)
-      cocoapods (>= 1.6.0, <= 1.8.0)
+      cocoapods (>= 1.6.0, <= 1.10.0)
 
 GEM
   remote: https://rubygems.org/

--- a/motion-cocoapods.gemspec
+++ b/motion-cocoapods.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.license     = 'BSD-2-Clause'
   spec.files       = Dir.glob('lib/**/*.rb') << 'README.md' << 'LICENSE'
 
-  spec.add_runtime_dependency 'cocoapods', '>= 1.6.0', '<= 1.8.0'
+  spec.add_runtime_dependency 'cocoapods', '>= 1.6.0', '<= 1.10.0'
 end


### PR DESCRIPTION
```
Pod::Informative: [!] `Realm` requires CocoaPods version `>= 1.10`, which is not satisfied by your current version, `1.8.0`.
```