### PR TITLE
updated cocoapods max version to 1.10.2 on gemspec dependency line

### DIFF
--- a/motion-cocoapods.gemspec
+++ b/motion-cocoapods.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.license     = 'BSD-2-Clause'
   spec.files       = Dir.glob('lib/**/*.rb') << 'README.md' << 'LICENSE'
 
-  spec.add_runtime_dependency 'cocoapods', '>= 1.6.0', '<= 1.10.0'
+  spec.add_runtime_dependency 'cocoapods', '>= 1.6.0', '<= 1.10.2'
 end


### PR DESCRIPTION
Hi Guys,

I was required to update this dependency from cocoapods to be able to run the latest Firebase SDK. Since it was a minor version updgrade (`'>= 1.6.0', '<= 1.10.0'`  to `'>= 1.6.0', '<= 1.10.2'`), probably it might be possible to upgrade the oficial repository with no harm. 